### PR TITLE
fix: optional fields in ComicInSearch

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -213,9 +213,9 @@ pub struct ComicInSearch {
     pub author: String,
     pub categories: Vec<String>,
     #[serde(rename = "chineseTeam")]
-    pub chinese_team: String,
+    pub chinese_team: Option<String>,
     pub created_at: String,
-    pub description: String,
+    pub description: Option<String>,
     pub finished: bool,
     #[serde(rename = "likesCount")]
     pub likes_count: i64,


### PR DESCRIPTION
服务器返回的JSON中，**ComicInSearch**的`chineseTeam`和`description`字段可能为空，而Rust代码中的**ComicInSearch**没有处理这种情况，导致出现错误。
本PR更新了**ComicInSearch**，正确处理`chineseTeam`和`description`字段。
解决这个issue #3 