### PR TITLE
refactor: remove Option and set defaults for `chinese_team` and `description`

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -212,10 +212,11 @@ pub struct ComicInSearch {
     pub id: String,
     pub author: String,
     pub categories: Vec<String>,
-    #[serde(rename = "chineseTeam")]
-    pub chinese_team: Option<String>,
+    #[serde(default, rename = "chineseTeam")]
+    pub chinese_team: String,
     pub created_at: String,
-    pub description: Option<String>,
+    #[serde(default)]
+    pub description: String,
     pub finished: bool,
     #[serde(rename = "likesCount")]
     pub likes_count: i64,


### PR DESCRIPTION
移除 `ComicInSearch` 结构体中 `chinese_team` 和 `description` 的Option类型，并为其设置默认值
解决这个issue #3 