### PR TITLE
fix: optional fields in ComicInfo and Creator

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -193,7 +193,9 @@ pub struct ComicInfo {
     pub likes_count: i32,
     #[serde(rename = "_creator")]
     pub creator: Creator,
+    #[serde(default)]
     pub description: String,
+    #[serde(default)]
     pub chinese_team: String,
     pub tags: Vec<String>,
     #[serde(rename = "updated_at")]
@@ -255,8 +257,10 @@ pub struct Creator {
     pub characters: Vec<String>,
     #[serde(default = "avatar_default")]
     pub avatar: Image,
+    #[serde(default)]
     pub slogan: String,
     pub role: String,
+    #[serde(default)]
     pub character: String,
 }
 


### PR DESCRIPTION
服务器返回的JSON中
- ComicInfo的`chineseTeam`与`description`
- Creator的`slogan`与`character`

这些字段都可能为空

而Rust代码中没有处理这种情况，导致出现错误。
本PR更新了`ComicInfo`和`Creator`，当字段不存在或者为null时，parse成空字符串
解决这个issue #6 