### PR TITLE
fix: optional fields in ComicInSearch

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -184,6 +184,7 @@ pub struct ComicInfo {
     #[serde(rename = "_id")]
     pub id: String,
     pub title: String,
+    #[serde(default)]
     pub author: String,
     pub pages_count: i32,
     pub eps_count: i32,
@@ -252,7 +253,7 @@ pub struct Creator {
     pub gender: String,
     pub name: String,
     pub title: String,
-    pub verified: bool,
+    pub verified: Option<bool>,
     pub exp: i32,
     pub level: i32,
     pub characters: Vec<String>,

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -212,6 +212,7 @@ pub struct ComicInfo {
 pub struct ComicInSearch {
     #[serde(rename = "_id")]
     pub id: String,
+    #[serde(default)]
     pub author: String,
     pub categories: Vec<String>,
     #[serde(default, rename = "chineseTeam")]


### PR DESCRIPTION
服务器返回的JSON中，ComicInSearch的`author`字段可能为空，而Rust代码中的ComicInSearch没有处理这种情况，导致出现错误。
本PR更新了ComicInSearch，正确处理`author`字段。
解决这个issue #8 