### PR TITLE
fix: optional fields in ComicInfo and Creator

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -184,6 +184,7 @@ pub struct ComicInfo {
     #[serde(rename = "_id")]
     pub id: String,
     pub title: String,
+    #[serde(default)]
     pub author: String,
     pub pages_count: i32,
     pub eps_count: i32,
@@ -251,7 +252,7 @@ pub struct Creator {
     pub gender: String,
     pub name: String,
     pub title: String,
-    pub verified: bool,
+    pub verified: Option<bool>,
     pub exp: i32,
     pub level: i32,
     pub characters: Vec<String>,


### PR DESCRIPTION
服务器返回的JSON中，ComicInfo的`author`和Creator的`verified`字段可能为空，而Rust代码没有处理这种情况，导致出现错误。
本PR更新了ComicInfo和Creator，正确处理可能为空的字段。
解决这个issue #10 